### PR TITLE
Feature/new stepper designs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@
 <img width="30%" height="2400" alt="Screenshot_20260215_234040" src="https://github.com/user-attachments/assets/7ce15525-de28-4aa9-82a5-d955f6b46f1a" />
 <img width="30%" height="2400" alt="Screenshot_20260215_234100" src="https://github.com/user-attachments/assets/0ae5dd69-e1d3-4ad9-a83e-351ce285f979" />
 
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 09 37 PM" src="https://github.com/user-attachments/assets/235cd7e5-ea06-4a79-a7b8-fce1fcfcad61" />
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 10 47 PM" src="https://github.com/user-attachments/assets/b718385c-8a02-42d8-8fa3-df9572e77e61" />
+
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 05 PM" src="https://github.com/user-attachments/assets/fd7aa447-7cf6-461a-95cc-7e9aaad33426" />
+
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 35 PM" src="https://github.com/user-attachments/assets/b70e47ee-faf5-49e7-b4be-1ef57144a44c" />
+
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,49 @@
 # StepMotion
 [![](https://jitpack.io/v/Ali0092/StepMotion-Lib.svg)](https://jitpack.io/#Ali0092/StepMotion-Lib)
 
-
-**StepMotion** is a lightweight, customizable, and elegant stepper UI library for Jetpack Compose. It helps you display multi-step progress in a clean and intuitive way — perfect for forms, onboarding flows, order tracking, and more.
-
----
-
-## ✨ Features
-
-- 🧽 Horizontal and Vertical Stepper with customizable steps and titles
-- 🎨 Full color customization (active, inactive, title, indicator)
-- ✅ Visually shows current, previous, and upcoming steps
-- 🧹 Easy to integrate and use with clean APIs
-- 💡 Ideal for progress tracking, sign-up forms, surveys, etc.
+**StepMotion** is a lightweight, customizable, and animated stepper UI library for Jetpack Compose. Display multi-step progress in a clean and intuitive way — perfect for forms, onboarding flows, order tracking, checkout flows, and more.
 
 ---
 
-## 📸 Preview
+## Features
+
+- 12 stepper variants — 6 horizontal + 6 vertical
+- Full color customization (active, inactive, title, indicator)
+- Smooth animations for state transitions (color, scale, checkmark, connector fill)
+- Visually shows current, previous, and upcoming steps
+- Clean, minimal APIs — drop in and go
+- Ideal for progress tracking, sign-up flows, surveys, checkout, onboarding, and more
+
+---
+
+## Preview
+
 <img width="30%" height="2400" alt="Screenshot_20260215_234011" src="https://github.com/user-attachments/assets/d269884e-5172-4019-a1d1-d09d5cf159d2" />
 <img width="30%" height="2400" alt="Screenshot_20260215_234040" src="https://github.com/user-attachments/assets/7ce15525-de28-4aa9-82a5-d955f6b46f1a" />
 <img width="30%" height="2400" alt="Screenshot_20260215_234100" src="https://github.com/user-attachments/assets/0ae5dd69-e1d3-4ad9-a83e-351ce285f979" />
 
-<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 09 37 PM" src="https://github.com/user-attachments/assets/235cd7e5-ea06-4a79-a7b8-fce1fcfcad61" />
-<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 10 47 PM" src="https://github.com/user-attachments/assets/b718385c-8a02-42d8-8fa3-df9572e77e61" />
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 09 37 PM" src="https://github.com/user-attachments/assets/235cd7e5-ea06-4a79-a7b8-fce1fcfcad61" />
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 10 47 PM" src="https://github.com/user-attachments/assets/b718385c-8a02-42d8-8fa3-df9572e77e61" />
 
-<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 05 PM" src="https://github.com/user-attachments/assets/fd7aa447-7cf6-461a-95cc-7e9aaad33426" />
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 05 PM" src="https://github.com/user-attachments/assets/fd7aa447-7cf6-461a-95cc-7e9aaad33426" />
 
-<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 35 PM" src="https://github.com/user-attachments/assets/b70e47ee-faf5-49e7-b4be-1ef57144a44c" />
-
-
+<img width="30%" height="2400" alt="Screenshot 2026-06-04 at 3 11 35 PM" src="https://github.com/user-attachments/assets/b70e47ee-faf5-49e7-b4be-1ef57144a44c" />
 
 ---
 
-## 🛠️ Installation
+## Installation
 
-Add JitPack to your root `build.gradle`:
+Add JitPack to your root `settings.gradle` (or `build.gradle`):
 
 ```gradle
-allprojects {
+dependencyResolutionManagement {
     repositories {
         maven { url 'https://jitpack.io' }
     }
 }
 ```
 
-Then, add the dependency in your module's `build.gradle`:
+Add the dependency in your module's `build.gradle`:
 
 ```gradle
 dependencies {
@@ -54,100 +53,72 @@ dependencies {
 
 ---
 
-## How to Use
+## Stepper Types
 
-StepMotion provides **4 stepper variants** to fit different UI needs. All steppers use a **0-based** `currentStep` index and animate smoothly between state changes.
+All steppers share a common set of required parameters and expose optional parameters for fine-tuning. Steps use a **0-based** `currentStep` index and animate smoothly between state changes.
+
+### Common Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `steps` | `List<String>` | Step labels to display |
+| `currentStep` | `Int` | Current step index (0-based) |
+| `activeColor` | `Color` | Color for completed and current step indicators |
+| `inactiveColor` | `Color` | Color for upcoming step indicators |
+| `activeTitleColor` | `Color` | Text color for completed and current steps |
+| `inactiveTitleColor` | `Color` | Text color for upcoming steps |
+| `modifier` | `Modifier` | Modifier to apply to the stepper |
 
 ---
 
-### 1. HorizontalSimpleStepper
+### 1. Simple Stepper
 
-A clean horizontal stepper with circle indicators and text labels below each step.
+A clean stepper with filled circle indicators and animated connectors.
 
-<!-- Screenshot placeholder -->
+#### HorizontalStepper
 
 ```kotlin
-HorizontalSimpleStepper(
-    steps = listOf("Profile", "Upload", "Review", "Done"),
-    currentStep = 2,
-    activeColor = Color(0xFF3F51B5),
-    inactiveColor = Color.LightGray,
-    activeTitleColor = Color.Black,
-    inactiveTitleColor = Color.Gray
+HorizontalStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Details", "Address", "Payment", "Done"),
+    currentStep = 1,
+    activeColor = Color(0xFF3B82F6),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF1E40AF),
+    inactiveTitleColor = Color(0xFF94A3B8)
 )
 ```
-
-**Optional parameters:**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
-| `circleFontSize` | `TextUnit` | `16.sp` | Font size for numbers inside circles |
+| `circleFontSize` | `TextUnit` | `14.sp` | Font size for numbers inside circles |
 | `titleFontSize` | `TextUnit` | `13.sp` | Font size for step labels |
-| `spacing` | `Dp` | `4.dp` | Vertical spacing between circle and label |
+| `spacing` | `Dp` | `4.dp` | Gap between circle and label |
 | `connectorThickness` | `Dp` | `2.dp` | Thickness of connector lines |
 | `borderWidth` | `Dp` | `2.dp` | Border width around the current step circle |
 | `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
 
----
-
-### 2. HorizontalAnimatedStepper
-
-A horizontal stepper with a pulse ring animation on the current step for added visual emphasis.
-
-<!-- Screenshot placeholder -->
-
-```kotlin
-HorizontalAnimatedStepper(
-    steps = listOf("Profile", "Upload", "Review", "Done"),
-    currentStep = 1,
-    activeColor = Color(0xFF3F51B5),
-    inactiveColor = Color.LightGray,
-    activeTitleColor = Color.Black,
-    inactiveTitleColor = Color.Gray
-)
-```
-
-**Optional parameters:**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
-| `circleFontSize` | `TextUnit` | `16.sp` | Font size for numbers inside circles |
-| `titleFontSize` | `TextUnit` | `12.sp` | Font size for step labels |
-| `spacing` | `Dp` | `6.dp` | Vertical spacing between circle and label |
-| `connectorThickness` | `Dp` | `3.dp` | Thickness of connector lines |
-| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
-| `enablePulseAnimation` | `Boolean` | `true` | Enable/disable pulse ring on current step |
-| `pulseAnimationDuration` | `Int` | `1000` | Duration of the pulse animation cycle |
-
----
-
-### 3. VerticalSimpleStepper
-
-A vertical stepper with circles on the left and text labels on the right, connected by vertical lines.
-
-<!-- Screenshot placeholder -->
+#### VerticalSimpleStepper
 
 ```kotlin
 VerticalSimpleStepper(
-    steps = listOf("Profile", "Upload", "Review", "Done"),
-    currentStep = 2,
-    activeColor = Color(0xFF3F51B5),
-    inactiveColor = Color.LightGray,
-    activeTitleColor = Color.Black,
-    inactiveTitleColor = Color.Gray
+    modifier = Modifier.fillMaxWidth().height(280.dp),
+    steps = listOf("Select", "Confirm", "Pay", "Complete"),
+    currentStep = 1,
+    activeColor = Color(0xFFF59E0B),
+    inactiveColor = Color(0xFFE2E8F0),
+    activeTitleColor = Color(0xFF92400E),
+    inactiveTitleColor = Color(0xFF94A3B8)
 )
 ```
-
-**Optional parameters:**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
-| `circleFontSize` | `TextUnit` | `16.sp` | Font size for numbers inside circles |
-| `titleFontSize` | `TextUnit` | `16.sp` | Font size for step labels |
-| `horizontalSpacing` | `Dp` | `16.dp` | Spacing between circles and text labels |
+| `circleFontSize` | `TextUnit` | `14.sp` | Font size for numbers inside circles |
+| `titleFontSize` | `TextUnit` | `14.sp` | Font size for step labels |
+| `horizontalSpacing` | `Dp` | `16.dp` | Gap between circles and text labels |
 | `verticalSpacing` | `Dp` | `4.dp` | Spacing around connector lines |
 | `connectorThickness` | `Dp` | `2.dp` | Thickness of connector lines |
 | `borderWidth` | `Dp` | `2.dp` | Border width around the current step circle |
@@ -155,33 +126,254 @@ VerticalSimpleStepper(
 
 ---
 
-### 4. VerticalCardStepper
+### 2. Animated Stepper
 
-A vertical stepper with expandable cards that show descriptions for the current step. Great for onboarding flows and order tracking.
+A horizontal stepper with a repeating pulse ring on the current step for extra visual emphasis.
 
-<!-- Screenshot placeholder -->
+#### HorizontalAnimatedStepper
 
 ```kotlin
-VerticalCardStepper(
-    steps = listOf("Profile", "Upload", "Review", "Done"),
-    descriptions = listOf(
-        "Fill in your personal details",
-        "Upload required documents",
-        "Review your application",
-        "You're all set!"
-    ),
+HorizontalAnimatedStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Cart", "Shipping", "Payment", "Confirm"),
     currentStep = 1,
-    activeColor = Color(0xFF3F51B5),
-    inactiveColor = Color.LightGray,
-    cardBackgroundColor = Color(0xFFF5F5F5),
-    activeCardBackgroundColor = Color(0xFFE8EAF6)
+    activeColor = Color(0xFF10B981),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF065F46),
+    inactiveTitleColor = Color(0xFF94A3B8)
 )
 ```
 
-**Optional parameters:**
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
+| `circleFontSize` | `TextUnit` | `14.sp` | Font size for numbers inside circles |
+| `titleFontSize` | `TextUnit` | `12.sp` | Font size for step labels |
+| `spacing` | `Dp` | `6.dp` | Gap between circle and label |
+| `connectorThickness` | `Dp` | `3.dp` | Thickness of connector lines |
+| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
+| `enablePulseAnimation` | `Boolean` | `true` | Toggle the pulse ring on current step |
+| `pulseAnimationDuration` | `Int` | `1000` | Duration of one pulse cycle in milliseconds |
+
+---
+
+### 3. Numbered Stepper
+
+Outlined circles for inactive steps, filled + outer glow ring for the current step, checkmark for completed steps.
+
+#### HorizontalNumberedStepper
+
+```kotlin
+HorizontalNumberedStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Details", "Review", "Payment", "Confirm"),
+    currentStep = 1,
+    activeColor = Color(0xFF7C3AED),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF4C1D95),
+    inactiveTitleColor = Color(0xFF94A3B8)
+)
+```
+
+#### VerticalNumberedStepper
+
+```kotlin
+VerticalNumberedStepper(
+    modifier = Modifier.fillMaxWidth().height(240.dp),
+    steps = listOf("Setup", "Configure", "Preview", "Launch"),
+    currentStep = 1,
+    activeColor = Color(0xFF0EA5E9),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF0C4A6E),
+    inactiveTitleColor = Color(0xFF94A3B8)
+)
+```
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
+| `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
+| `circleFontSize` | `TextUnit` | `14.sp` | Font size for numbers inside circles |
+| `titleFontSize` | `TextUnit` | `13.sp` | Font size for step labels |
+| `connectorThickness` | `Dp` | `2.dp` | Thickness of connector lines |
+| `outerRingWidth` | `Dp` | `2.dp` | Width of the outer glow ring on the current step |
+| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
+
+---
+
+### 4. Icon Stepper
+
+Per-step custom icons — outlined and tinted when inactive, white on filled background when active, checkmark when completed.
+
+#### HorizontalIconStepper
+
+```kotlin
+HorizontalIconStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Profile", "Home", "Cart", "Done"),
+    icons = listOf(
+        Icons.Rounded.Person,
+        Icons.Rounded.Home,
+        Icons.Rounded.ShoppingCart,
+        Icons.Rounded.Star
+    ),
+    currentStep = 1,
+    activeColor = Color(0xFFF59E0B),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF78350F),
+    inactiveTitleColor = Color(0xFF94A3B8)
+)
+```
+
+#### VerticalIconStepper
+
+```kotlin
+VerticalIconStepper(
+    modifier = Modifier.fillMaxWidth().height(240.dp),
+    steps = listOf("Account", "Address", "Wishlist", "Favourites"),
+    icons = listOf(
+        Icons.Rounded.Person,
+        Icons.Rounded.Home,
+        Icons.Rounded.Star,
+        Icons.Rounded.Favorite
+    ),
+    currentStep = 1,
+    activeColor = Color(0xFFEC4899),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF831843),
+    inactiveTitleColor = Color(0xFF94A3B8)
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `icons` | `List<ImageVector>` | — | Custom icon for each step (must match `steps` length) |
+| `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
+| `iconSize` | `Dp` | `18.dp` | Size of the icon drawn inside the circle |
+| `titleFontSize` | `TextUnit` | `13.sp` | Font size for step labels |
+| `connectorThickness` | `Dp` | `2.dp` | Thickness of connector lines |
+| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
+
+---
+
+### 5. Rounded Stepper
+
+Rounded-rectangle badge indicators instead of circles — configurable corner radius, not fully pill-shaped.
+
+#### HorizontalRoundedStepper
+
+```kotlin
+HorizontalRoundedStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Symptoms", "History", "Rx", "Done"),
+    currentStep = 1,
+    activeColor = Color(0xFF10B981),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF064E3B),
+    inactiveTitleColor = Color(0xFF94A3B8),
+    cornerRadius = 10.dp
+)
+```
+
+#### VerticalRoundedStepper
+
+```kotlin
+VerticalRoundedStepper(
+    modifier = Modifier.fillMaxWidth().height(260.dp),
+    steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
+    currentStep = 1,
+    activeColor = Color(0xFF6366F1),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF312E81),
+    inactiveTitleColor = Color(0xFF94A3B8),
+    cornerRadius = 10.dp
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `badgeWidth` | `Dp` | `44.dp` | Width of each badge indicator |
+| `badgeHeight` | `Dp` | `32.dp` | Height of each badge indicator |
+| `cornerRadius` | `Dp` | `10.dp` | Corner radius of the badge (0 = rectangle, high value = pill) |
+| `circleFontSize` | `TextUnit` | `14.sp` | Font size for numbers inside badges |
+| `titleFontSize` | `TextUnit` | `13.sp` | Font size for step labels |
+| `connectorThickness` | `Dp` | `2.dp` | Thickness of connector lines |
+| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
+
+---
+
+### 6. Progress Bar Stepper
+
+A thick continuous bar with step dots on top — dots fill from left to right with half-fill on the current step.
+
+#### HorizontalProgressBarStepper
+
+```kotlin
+HorizontalProgressBarStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Start", "Design", "Build", "Test", "Ship"),
+    currentStep = 2,
+    activeColor = Color(0xFFEF4444),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF7F1D1D),
+    inactiveTitleColor = Color(0xFF94A3B8),
+    barThickness = 6.dp
+)
+```
+
+#### VerticalProgressBarStepper
+
+```kotlin
+VerticalProgressBarStepper(
+    modifier = Modifier.fillMaxWidth().height(300.dp),
+    steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+    currentStep = 2,
+    activeColor = Color(0xFF14B8A6),
+    inactiveColor = Color(0xFFCBD5E1),
+    activeTitleColor = Color(0xFF134E4A),
+    inactiveTitleColor = Color(0xFF94A3B8),
+    barThickness = 6.dp
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `dotSize` | `Dp` | `16.dp` | Diameter of each step dot |
+| `barThickness` | `Dp` | `4.dp` | Thickness of the continuous progress bar |
+| `titleFontSize` | `TextUnit` | `13.sp` | Font size for step labels |
+| `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
+
+---
+
+### 7. Card Stepper
+
+A vertical stepper with expandable cards showing a description for each step. Great for onboarding and order tracking.
+
+#### VerticalCardStepper
+
+```kotlin
+VerticalCardStepper(
+    modifier = Modifier.fillMaxWidth(),
+    steps = listOf("Create Account", "Personal Info", "Preferences", "Verification", "All Set!"),
+    descriptions = listOf(
+        "Sign up with your email and create a password",
+        "Tell us your name and contact details",
+        "Choose your notification and display preferences",
+        "Verify your email address to continue",
+        "Your account is ready to use"
+    ),
+    currentStep = 1,
+    activeColor = Color(0xFF8B5CF6),
+    inactiveColor = Color(0xFF94A3B8),
+    activeCardBackgroundColor = Color(0xFFF5F3FF),
+    cardBackgroundColor = Color(0xFFFFFFFF)
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `descriptions` | `List<String>` | — | Description shown inside each card |
+| `activeCardBackgroundColor` | `Color` | — | Background color of the active card |
+| `cardBackgroundColor` | `Color` | — | Background color of inactive cards |
 | `circleSize` | `Dp` | `32.dp` | Size of step indicator circles |
 | `circleFontSize` | `TextUnit` | `15.sp` | Font size for numbers inside circles |
 | `titleFontSize` | `TextUnit` | `15.sp` | Font size for step titles |
@@ -189,34 +381,20 @@ VerticalCardStepper(
 | `cardRadius` | `Dp` | `12.dp` | Corner radius for step cards |
 | `cardPadding` | `Dp` | `14.dp` | Padding inside step cards |
 | `cardSpacing` | `Dp` | `8.dp` | Spacing between step cards |
-| `horizontalSpacing` | `Dp` | `12.dp` | Spacing between circles and cards |
+| `horizontalSpacing` | `Dp` | `12.dp` | Gap between circles and cards |
 | `connectorThickness` | `Dp` | `3.dp` | Thickness of connector lines |
-| `accentBorderWidth` | `Dp` | `4.dp` | Width of the colored accent border on cards |
+| `accentBorderWidth` | `Dp` | `4.dp` | Width of the accent border on the active card |
 | `animationDuration` | `Int` | `400` | Animation duration in milliseconds |
 
 ---
 
-### Common Parameters (all steppers)
-
-| Parameter | Type | Description |
-|---|---|---|
-| `steps` | `List<String>` | List of step labels to display |
-| `currentStep` | `Int` | Current step index (0-based) |
-| `activeColor` | `Color` | Color for completed and current step indicators |
-| `inactiveColor` | `Color` | Color for future/upcoming step indicators |
-| `activeTitleColor` | `Color` | Text color for completed and current steps |
-| `inactiveTitleColor` | `Color` | Text color for future steps |
-| `modifier` | `Modifier` | Modifier to apply to the stepper |
-
----
-
-## 🤝 Contribution
+## Contribution
 
 Feel free to fork, star, or suggest improvements via issues and pull requests.
 
 ---
 
-## 📄 License
+## License
 
 ```
 MIT License
@@ -244,15 +422,14 @@ SOFTWARE.
 
 ---
 
-## 👤 Author
+## Author
 
 **Muhammad Ali**\
-📧 [aliatwork364@gmail.com](mailto\:aliatwork364@gmail.com)\
+📧 [aliatwork364@gmail.com](mailto:aliatwork364@gmail.com)\
 🌐 [Portfolio](https://muhammadali0092.netlify.app)\
 💼 [LinkedIn](https://www.linkedin.com/in/muhammad-ali-a28422222)\
 💻 [GitHub](https://github.com/Ali0092)
 
 ---
 
-> *“Step into motion — guide your users one smooth step at a time.”*
-
+> *"Step into motion — guide your users one smooth step at a time."*

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/src/main/java/com/example/stepmotion/MainActivity.kt
+++ b/app/src/main/java/com/example/stepmotion/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,6 +34,7 @@ import androidx.compose.material.icons.rounded.ShoppingCart
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.stepmotion.ui.theme.StepMotionTheme
@@ -80,10 +82,12 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.padding(bottom = 28.dp)
                     )
 
-                    // 1. Horizontal Simple Stepper — Default Configuration
+                    // ── Simple Stepper ────────────────────────────────────
+                    TypeHeader("Simple Stepper")
+
                     StepperSection(
-                        title = "Horizontal Simple - Default",
-                        subtitle = "Clean & minimal step indicator with new API",
+                        title = "Horizontal — Default",
+                        subtitle = "Clean & minimal circles with animated connector",
                         accentColor = Color(0xFF3B82F6),
                         stepCount = 5,
                     ) { selectedIndex ->
@@ -100,9 +104,8 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 2. Horizontal Simple Stepper — Large & Custom
                     StepperSection(
-                        title = "Horizontal Simple - Large Custom",
+                        title = "Horizontal — Large Custom",
                         subtitle = "Larger circles, custom spacing & thick connectors",
                         accentColor = Color(0xFF8B5CF6),
                         stepCount = 3,
@@ -115,7 +118,6 @@ class MainActivity : ComponentActivity() {
                             inactiveColor = Color(0xFFCBD5E1),
                             activeTitleColor = Color(0xFF6B21A8),
                             inactiveTitleColor = Color(0xFF94A3B8),
-                            // Custom sizes
                             circleSize = 42.dp,
                             titleFontSize = 16.sp,
                             spacing = 8.dp,
@@ -125,9 +127,55 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 3. Horizontal Animated Stepper — Default
                     StepperSection(
-                        title = "Horizontal Animated - Default",
+                        title = "Vertical — Default",
+                        subtitle = "Classic vertical timeline layout",
+                        accentColor = Color(0xFFF59E0B),
+                        stepCount = 5,
+                    ) { selectedIndex ->
+                        VerticalSimpleStepper(
+                            modifier = Modifier.fillMaxWidth().height(280.dp),
+                            steps = listOf(
+                                "Select Service", "Choose Provider",
+                                "Pick Date & Time", "Confirm Details", "Booking Complete"
+                            ),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFFF59E0B),
+                            inactiveColor = Color(0xFFE2E8F0),
+                            activeTitleColor = Color(0xFF92400E),
+                            inactiveTitleColor = Color(0xFF94A3B8)
+                        )
+                    }
+
+                    SectionDivider()
+
+                    StepperSection(
+                        title = "Vertical — Large & Spacious",
+                        subtitle = "Bigger circles, larger fonts, more spacing",
+                        accentColor = Color(0xFF06B6D4),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        VerticalSimpleStepper(
+                            modifier = Modifier.fillMaxWidth().height(320.dp),
+                            steps = listOf("Design", "Develop", "Test", "Deploy"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF06B6D4),
+                            inactiveColor = Color(0xFFE2E8F0),
+                            activeTitleColor = Color(0xFF164E63),
+                            inactiveTitleColor = Color(0xFF94A3B8),
+                            circleSize = 44.dp,
+                            circleFontSize = 20.sp,
+                            titleFontSize = 18.sp,
+                            verticalSpacing = 8.dp,
+                            connectorThickness = 3.dp
+                        )
+                    }
+
+                    // ── Animated Stepper ──────────────────────────────────
+                    TypeHeader("Animated Stepper")
+
+                    StepperSection(
+                        title = "Horizontal — Default",
                         subtitle = "Pulse ring, bouncy checkmarks & progress fill",
                         accentColor = Color(0xFF10B981),
                         stepCount = 5,
@@ -145,9 +193,8 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 4. Horizontal Animated Stepper — Custom Fast Animation
                     StepperSection(
-                        title = "Horizontal Animated - Fast & Compact",
+                        title = "Horizontal — Fast & Compact",
                         subtitle = "Smaller circles, faster animations, no pulse",
                         accentColor = Color(0xFFEF4444),
                         stepCount = 4,
@@ -160,7 +207,6 @@ class MainActivity : ComponentActivity() {
                             inactiveColor = Color(0xFFCBD5E1),
                             activeTitleColor = Color(0xFF991B1B),
                             inactiveTitleColor = Color(0xFF94A3B8),
-                            // Custom configuration
                             circleSize = 32.dp,
                             titleFontSize = 11.sp,
                             spacing = 4.dp,
@@ -169,84 +215,20 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    SectionDivider()
+                    // ── Card Stepper ──────────────────────────────────────
+                    TypeHeader("Card Stepper")
 
-                    // 5. Vertical Simple Stepper — Default
                     StepperSection(
-                        title = "Vertical Simple - Default",
-                        subtitle = "Classic vertical timeline layout",
-                        accentColor = Color(0xFFF59E0B),
-                        stepCount = 5,
-                    ) { selectedIndex ->
-                        VerticalSimpleStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(280.dp),
-                            steps = listOf(
-                                "Select Service",
-                                "Choose Provider",
-                                "Pick Date & Time",
-                                "Confirm Details",
-                                "Booking Complete",
-                            ),
-                            currentStep = selectedIndex,
-                            activeColor = Color(0xFFF59E0B),
-                            inactiveColor = Color(0xFFE2E8F0),
-                            activeTitleColor = Color(0xFF92400E),
-                            inactiveTitleColor = Color(0xFF94A3B8)
-                        )
-                    }
-
-                    SectionDivider()
-
-                    // 6. Vertical Simple Stepper — Large & Spacious
-                    StepperSection(
-                        title = "Vertical Simple - Large & Spacious",
-                        subtitle = "Bigger circles, larger fonts, more spacing",
-                        accentColor = Color(0xFF06B6D4),
-                        stepCount = 4,
-                    ) { selectedIndex ->
-                        VerticalSimpleStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(320.dp),
-                            steps = listOf(
-                                "Design",
-                                "Develop",
-                                "Test",
-                                "Deploy",
-                            ),
-                            currentStep = selectedIndex,
-                            activeColor = Color(0xFF06B6D4),
-                            inactiveColor = Color(0xFFE2E8F0),
-                            activeTitleColor = Color(0xFF164E63),
-                            inactiveTitleColor = Color(0xFF94A3B8),
-                            // Custom sizes
-                            circleSize = 44.dp,
-                            circleFontSize = 20.sp,
-                            titleFontSize = 18.sp,
-                            verticalSpacing = 8.dp,
-                            connectorThickness = 3.dp
-                        )
-                    }
-
-                    SectionDivider()
-
-                    // 7. Vertical Card Stepper — Default
-                    StepperSection(
-                        title = "Vertical Card - Default",
-                        subtitle = "Cards with expand, crossfade & accent border",
+                        title = "Vertical — Default",
+                        subtitle = "Expandable cards with crossfade & accent border",
                         accentColor = Color(0xFF8B5CF6),
                         stepCount = 5,
                     ) { selectedIndex ->
                         VerticalCardStepper(
                             modifier = Modifier.fillMaxWidth(),
                             steps = listOf(
-                                "Create Account",
-                                "Personal Info",
-                                "Preferences",
-                                "Verification",
-                                "All Set!",
+                                "Create Account", "Personal Info",
+                                "Preferences", "Verification", "All Set!"
                             ),
                             descriptions = listOf(
                                 "Sign up with your email and create a password",
@@ -265,20 +247,15 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 8. Vertical Card Stepper — Custom Compact Style
                     StepperSection(
-                        title = "Vertical Card - Compact Custom",
+                        title = "Vertical — Compact Custom",
                         subtitle = "Smaller cards, tight spacing, custom styling",
                         accentColor = Color(0xFFEC4899),
                         stepCount = 3,
                     ) { selectedIndex ->
                         VerticalCardStepper(
                             modifier = Modifier.fillMaxWidth(),
-                            steps = listOf(
-                                "Upload",
-                                "Process",
-                                "Complete",
-                            ),
+                            steps = listOf("Upload", "Process", "Complete"),
                             descriptions = listOf(
                                 "Select and upload your files",
                                 "Processing your documents",
@@ -289,7 +266,6 @@ class MainActivity : ComponentActivity() {
                             inactiveColor = Color(0xFF94A3B8),
                             activeCardBackgroundColor = Color(0xFFFDF2F8),
                             cardBackgroundColor = Color(0xFFFFFFFF),
-                            // Custom styling
                             circleSize = 32.dp,
                             circleFontSize = 14.sp,
                             titleFontSize = 14.sp,
@@ -302,12 +278,12 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    SectionDivider()
+                    // ── Numbered Stepper ──────────────────────────────────
+                    TypeHeader("Numbered Stepper")
 
-                    // 9. Horizontal Numbered Stepper — Default (NFT/flow style)
                     StepperSection(
-                        title = "Horizontal Numbered - Default",
-                        subtitle = "Outlined inactive circles, filled active, outer ring on current",
+                        title = "Horizontal — Default",
+                        subtitle = "Outlined inactive, filled active, outer ring on current",
                         accentColor = Color(0xFF7C3AED),
                         stepCount = 4,
                     ) { selectedIndex ->
@@ -324,17 +300,14 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 10. Vertical Numbered Stepper — Default
                     StepperSection(
-                        title = "Vertical Numbered - Default",
+                        title = "Vertical — Default",
                         subtitle = "Outlined inactive circles with outer ring on current step",
                         accentColor = Color(0xFF0EA5E9),
                         stepCount = 4,
                     ) { selectedIndex ->
                         VerticalNumberedStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(240.dp),
+                            modifier = Modifier.fillMaxWidth().height(240.dp),
                             steps = listOf("Setup", "Configure", "Preview", "Launch"),
                             currentStep = selectedIndex,
                             activeColor = Color(0xFF0EA5E9),
@@ -344,12 +317,12 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    SectionDivider()
+                    // ── Icon Stepper ──────────────────────────────────────
+                    TypeHeader("Icon Stepper")
 
-                    // 11. Horizontal Icon Stepper — Custom icons per step
                     StepperSection(
-                        title = "Horizontal Icon - Custom Icons",
-                        subtitle = "Per-step icons: outlined when inactive, white when active",
+                        title = "Horizontal — Custom Icons",
+                        subtitle = "Per-step icons: outlined inactive, white when active",
                         accentColor = Color(0xFFF59E0B),
                         stepCount = 4,
                     ) { selectedIndex ->
@@ -357,10 +330,8 @@ class MainActivity : ComponentActivity() {
                             modifier = Modifier.fillMaxWidth(),
                             steps = listOf("Profile", "Home", "Cart", "Done"),
                             icons = listOf(
-                                Icons.Rounded.Person,
-                                Icons.Rounded.Home,
-                                Icons.Rounded.ShoppingCart,
-                                Icons.Rounded.Star
+                                Icons.Rounded.Person, Icons.Rounded.Home,
+                                Icons.Rounded.ShoppingCart, Icons.Rounded.Star
                             ),
                             currentStep = selectedIndex,
                             activeColor = Color(0xFFF59E0B),
@@ -372,23 +343,18 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 12. Vertical Icon Stepper — Custom icons per step
                     StepperSection(
-                        title = "Vertical Icon - Custom Icons",
+                        title = "Vertical — Custom Icons",
                         subtitle = "Vertical layout with per-step icons",
                         accentColor = Color(0xFFEC4899),
                         stepCount = 4,
                     ) { selectedIndex ->
                         VerticalIconStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(240.dp),
+                            modifier = Modifier.fillMaxWidth().height(240.dp),
                             steps = listOf("Account", "Address", "Wishlist", "Favourites"),
                             icons = listOf(
-                                Icons.Rounded.Person,
-                                Icons.Rounded.Home,
-                                Icons.Rounded.Star,
-                                Icons.Rounded.Favorite
+                                Icons.Rounded.Person, Icons.Rounded.Home,
+                                Icons.Rounded.Star, Icons.Rounded.Favorite
                             ),
                             currentStep = selectedIndex,
                             activeColor = Color(0xFFEC4899),
@@ -398,11 +364,11 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    SectionDivider()
+                    // ── Rounded Stepper ───────────────────────────────────
+                    TypeHeader("Rounded Stepper")
 
-                    // 13. Horizontal Rounded Stepper — Nightingale style
                     StepperSection(
-                        title = "Horizontal Rounded - Badge Style",
+                        title = "Horizontal — Badge Style",
                         subtitle = "Rounded-rectangle badges, not fully rounded corners",
                         accentColor = Color(0xFF10B981),
                         stepCount = 4,
@@ -421,17 +387,14 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 14. Vertical Rounded Stepper — Nightingale style
                     StepperSection(
-                        title = "Vertical Rounded - Badge Style",
-                        subtitle = "Vertical layout with softly-cornered rectangular badges",
+                        title = "Vertical — Badge Style",
+                        subtitle = "Softly-cornered rectangular badges in vertical layout",
                         accentColor = Color(0xFF6366F1),
                         stepCount = 4,
                     ) { selectedIndex ->
                         VerticalRoundedStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(260.dp),
+                            modifier = Modifier.fillMaxWidth().height(260.dp),
                             steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
                             currentStep = selectedIndex,
                             activeColor = Color(0xFF6366F1),
@@ -442,12 +405,12 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    SectionDivider()
+                    // ── Progress Bar Stepper ──────────────────────────────
+                    TypeHeader("Progress Bar Stepper")
 
-                    // 15. Horizontal Progress Bar Stepper
                     StepperSection(
-                        title = "Horizontal Progress Bar",
-                        subtitle = "Continuous bar with dots on top, half-fill on current step",
+                        title = "Horizontal — Default",
+                        subtitle = "Continuous bar with dots on top, half-fill on current",
                         accentColor = Color(0xFFEF4444),
                         stepCount = 5,
                     ) { selectedIndex ->
@@ -465,18 +428,18 @@ class MainActivity : ComponentActivity() {
 
                     SectionDivider()
 
-                    // 16. Vertical Progress Bar Stepper
                     StepperSection(
-                        title = "Vertical Progress Bar",
-                        subtitle = "Vertical continuous bar with dots, labels to the right",
+                        title = "Vertical — Default",
+                        subtitle = "Vertical bar with dots, labels to the right",
                         accentColor = Color(0xFF14B8A6),
                         stepCount = 5,
                     ) { selectedIndex ->
                         VerticalProgressBarStepper(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(300.dp),
-                            steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+                            modifier = Modifier.fillMaxWidth().height(300.dp),
+                            steps = listOf(
+                                "Order placed", "Processing",
+                                "Shipped", "Out for delivery", "Delivered"
+                            ),
                             currentStep = selectedIndex,
                             activeColor = Color(0xFF14B8A6),
                             inactiveColor = Color(0xFFCBD5E1),
@@ -490,6 +453,28 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun TypeHeader(name: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f), color = Color(0xFFE2E8F0))
+        Text(
+            text = name.uppercase(),
+            modifier = Modifier.padding(horizontal = 12.dp),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF64748B),
+            textAlign = TextAlign.Center,
+            letterSpacing = 1.5.sp
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f), color = Color(0xFFE2E8F0))
     }
 }
 

--- a/app/src/main/java/com/example/stepmotion/MainActivity.kt
+++ b/app/src/main/java/com/example/stepmotion/MainActivity.kt
@@ -25,16 +25,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.ShoppingCart
+import androidx.compose.material.icons.rounded.Star
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.stepmotion.ui.theme.StepMotionTheme
-import com.example.stepmotionlib.HorizontalAnimatedStepper
-import com.example.stepmotionlib.HorizontalSimpleStepper
-import com.example.stepmotionlib.VerticalCardStepper
-import com.example.stepmotionlib.VerticalSimpleStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalAnimatedStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalIconStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalNumberedStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalProgressBarStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalRoundedStepper
+import com.example.stepmotionlib.horizontal_steppers.HorizontalStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalCardStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalIconStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalNumberedStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalProgressBarStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalRoundedStepper
+import com.example.stepmotionlib.vertical_stepper.VerticalSimpleStepper
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,7 +87,7 @@ class MainActivity : ComponentActivity() {
                         accentColor = Color(0xFF3B82F6),
                         stepCount = 5,
                     ) { selectedIndex ->
-                        HorizontalSimpleStepper(
+                        HorizontalStepper(
                             modifier = Modifier.fillMaxWidth(),
                             steps = listOf("Details", "Address", "Payment", "Review", "Done"),
                             currentStep = selectedIndex,
@@ -94,7 +107,7 @@ class MainActivity : ComponentActivity() {
                         accentColor = Color(0xFF8B5CF6),
                         stepCount = 3,
                     ) { selectedIndex ->
-                        HorizontalSimpleStepper(
+                        HorizontalStepper(
                             modifier = Modifier.fillMaxWidth(),
                             steps = listOf("Start", "Process", "Finish"),
                             currentStep = selectedIndex,
@@ -286,6 +299,190 @@ class MainActivity : ComponentActivity() {
                             cardSpacing = 6.dp,
                             connectorThickness = 2.dp,
                             accentBorderWidth = 3.dp
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 9. Horizontal Numbered Stepper — Default (NFT/flow style)
+                    StepperSection(
+                        title = "Horizontal Numbered - Default",
+                        subtitle = "Outlined inactive circles, filled active, outer ring on current",
+                        accentColor = Color(0xFF7C3AED),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        HorizontalNumberedStepper(
+                            modifier = Modifier.fillMaxWidth(),
+                            steps = listOf("Details", "Review", "Payment", "Confirm"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF7C3AED),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF4C1D95),
+                            inactiveTitleColor = Color(0xFF94A3B8)
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 10. Vertical Numbered Stepper — Default
+                    StepperSection(
+                        title = "Vertical Numbered - Default",
+                        subtitle = "Outlined inactive circles with outer ring on current step",
+                        accentColor = Color(0xFF0EA5E9),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        VerticalNumberedStepper(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(240.dp),
+                            steps = listOf("Setup", "Configure", "Preview", "Launch"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF0EA5E9),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF0C4A6E),
+                            inactiveTitleColor = Color(0xFF94A3B8)
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 11. Horizontal Icon Stepper — Custom icons per step
+                    StepperSection(
+                        title = "Horizontal Icon - Custom Icons",
+                        subtitle = "Per-step icons: outlined when inactive, white when active",
+                        accentColor = Color(0xFFF59E0B),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        HorizontalIconStepper(
+                            modifier = Modifier.fillMaxWidth(),
+                            steps = listOf("Profile", "Home", "Cart", "Done"),
+                            icons = listOf(
+                                Icons.Rounded.Person,
+                                Icons.Rounded.Home,
+                                Icons.Rounded.ShoppingCart,
+                                Icons.Rounded.Star
+                            ),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFFF59E0B),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF78350F),
+                            inactiveTitleColor = Color(0xFF94A3B8)
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 12. Vertical Icon Stepper — Custom icons per step
+                    StepperSection(
+                        title = "Vertical Icon - Custom Icons",
+                        subtitle = "Vertical layout with per-step icons",
+                        accentColor = Color(0xFFEC4899),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        VerticalIconStepper(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(240.dp),
+                            steps = listOf("Account", "Address", "Wishlist", "Favourites"),
+                            icons = listOf(
+                                Icons.Rounded.Person,
+                                Icons.Rounded.Home,
+                                Icons.Rounded.Star,
+                                Icons.Rounded.Favorite
+                            ),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFFEC4899),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF831843),
+                            inactiveTitleColor = Color(0xFF94A3B8)
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 13. Horizontal Rounded Stepper — Nightingale style
+                    StepperSection(
+                        title = "Horizontal Rounded - Badge Style",
+                        subtitle = "Rounded-rectangle badges, not fully rounded corners",
+                        accentColor = Color(0xFF10B981),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        HorizontalRoundedStepper(
+                            modifier = Modifier.fillMaxWidth(),
+                            steps = listOf("Symptoms", "History", "Rx", "Done"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF10B981),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF064E3B),
+                            inactiveTitleColor = Color(0xFF94A3B8),
+                            cornerRadius = 10.dp
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 14. Vertical Rounded Stepper — Nightingale style
+                    StepperSection(
+                        title = "Vertical Rounded - Badge Style",
+                        subtitle = "Vertical layout with softly-cornered rectangular badges",
+                        accentColor = Color(0xFF6366F1),
+                        stepCount = 4,
+                    ) { selectedIndex ->
+                        VerticalRoundedStepper(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(260.dp),
+                            steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF6366F1),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF312E81),
+                            inactiveTitleColor = Color(0xFF94A3B8),
+                            cornerRadius = 10.dp
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 15. Horizontal Progress Bar Stepper
+                    StepperSection(
+                        title = "Horizontal Progress Bar",
+                        subtitle = "Continuous bar with dots on top, half-fill on current step",
+                        accentColor = Color(0xFFEF4444),
+                        stepCount = 5,
+                    ) { selectedIndex ->
+                        HorizontalProgressBarStepper(
+                            modifier = Modifier.fillMaxWidth(),
+                            steps = listOf("Start", "Design", "Build", "Test", "Ship"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFFEF4444),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF7F1D1D),
+                            inactiveTitleColor = Color(0xFF94A3B8),
+                            barThickness = 6.dp
+                        )
+                    }
+
+                    SectionDivider()
+
+                    // 16. Vertical Progress Bar Stepper
+                    StepperSection(
+                        title = "Vertical Progress Bar",
+                        subtitle = "Vertical continuous bar with dots, labels to the right",
+                        accentColor = Color(0xFF14B8A6),
+                        stepCount = 5,
+                    ) { selectedIndex ->
+                        VerticalProgressBarStepper(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(300.dp),
+                            steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+                            currentStep = selectedIndex,
+                            activeColor = Color(0xFF14B8A6),
+                            inactiveColor = Color(0xFFCBD5E1),
+                            activeTitleColor = Color(0xFF134E4A),
+                            inactiveTitleColor = Color(0xFF94A3B8),
+                            barThickness = 6.dp
                         )
                     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/stepmotionlib/build.gradle.kts
+++ b/stepmotionlib/build.gradle.kts
@@ -57,5 +57,6 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
-
+    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.material.icons.extended)
 }

--- a/stepmotionlib/build.gradle.kts
+++ b/stepmotionlib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.github.ali0092"
-version = "1.0.4"
+version = "1.0.5"
 
 android {
     namespace = "com.example.stepmotionlib"

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalAnimatedStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalAnimatedStepper.kt
@@ -1,4 +1,4 @@
-package com.example.stepmotionlib
+package com.example.stepmotionlib.horizontal_steppers
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
@@ -41,7 +41,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
 import kotlinx.coroutines.launch
+import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * A horizontal animated stepper component with pulse effects on the current step.
@@ -155,7 +157,7 @@ private fun AnimatedStepIndicator(
             else -> inactiveColor.copy(alpha = 0.3f)
         },
         animationSpec = tween(animationDuration),
-        label = "indicatorBg"
+        label = "indicatorBackground"
     )
 
     val scale by animateFloatAsState(
@@ -319,4 +321,51 @@ private fun AnimatedConnectorLine(
             )
         }
     }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "HorizontalAnimated – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalAnimatedPreview_Step1() {
+    HorizontalAnimatedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Cart", "Shipping", "Payment", "Done"),
+        currentStep = 0,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF065F46),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalAnimated – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalAnimatedPreview_Step2() {
+    HorizontalAnimatedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Cart", "Shipping", "Payment", "Done"),
+        currentStep = 2,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF065F46),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalAnimated – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalAnimatedPreview_Complete() {
+    HorizontalAnimatedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Cart", "Shipping", "Payment", "Done"),
+        currentStep = 3,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF065F46),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
 }

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalIconStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalIconStepper.kt
@@ -1,0 +1,326 @@
+package com.example.stepmotionlib.horizontal_steppers
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.ShoppingCart
+import androidx.compose.material.icons.rounded.Star
+
+/**
+ * A horizontal stepper that shows custom icons inside step indicators.
+ * Inactive steps display the custom icon in an outlined circle (no fill).
+ * The current step shows the icon filled with the active color (icon in white).
+ * Completed steps replace the icon with a checkmark.
+ *
+ * @param steps List of step labels
+ * @param icons List of icons matching steps (one icon per step)
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for active and completed steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param circleSize Size of the step indicator circles
+ * @param iconSize Size of the icons inside circles
+ * @param titleFontSize Font size for step labels
+ * @param spacing Vertical spacing between circles and labels
+ * @param connectorThickness Thickness of connector lines
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun HorizontalIconStepper(
+    steps: List<String>,
+    icons: List<ImageVector>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    circleSize: Dp = StepperDefaults.SmallCircleSize,
+    iconSize: Dp = 18.dp,
+    titleFontSize: TextUnit = StepperDefaults.MediumTitleFontSize,
+    spacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.ThinConnector,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        steps.forEachIndexed { index, title ->
+            val icon = icons.getOrNull(index)
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.wrapContentWidth()
+            ) {
+                IconHIndicator(
+                    icon = icon,
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    circleSize = circleSize,
+                    iconSize = iconSize,
+                    animationDuration = animationDuration
+                )
+                Spacer(modifier = Modifier.height(spacing))
+                IconHLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    animationDuration = animationDuration
+                )
+            }
+
+            if (index < steps.lastIndex) {
+                IconHConnector(
+                    modifier = Modifier
+                        .weight(1f)
+                        .align(Alignment.Top)
+                        .padding(
+                            top = circleSize / 2 - connectorThickness / 2,
+                            start = 4.dp,
+                            end = 4.dp
+                        ),
+                    isPrevious = index < currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    thickness = connectorThickness
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconHIndicator(
+    icon: ImageVector?,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    circleSize: Dp,
+    iconSize: Dp,
+    animationDuration: Int
+) {
+    val fillAlpha by animateFloatAsState(
+        targetValue = if (isNext) 0f else 1f,
+        animationSpec = tween(animationDuration),
+        label = "fillAlpha"
+    )
+
+    val strokeColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.5f) else activeColor,
+        animationSpec = tween(animationDuration),
+        label = "strokeColor"
+    )
+
+    val iconTint by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.55f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "iconTint"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.1f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(circleSize)
+            .scale(scale)
+            .drawBehind {
+                drawCircle(color = activeColor.copy(alpha = fillAlpha))
+                drawCircle(
+                    color = strokeColor,
+                    style = Stroke(width = 2.dp.toPx())
+                )
+            }
+    ) {
+        AnimatedContent(
+            targetState = isPrevious,
+            transitionSpec = {
+                (fadeIn(tween(280)) + scaleIn(tween(280)))
+                    .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+            },
+            label = "iconContent"
+        ) { showCheck ->
+            if (showCheck) {
+                Image(
+                    imageVector = Icons.Rounded.Check,
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(Color.White),
+                    modifier = Modifier.size(iconSize)
+                )
+            } else if (icon != null) {
+                Image(
+                    imageVector = icon,
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(iconTint),
+                    modifier = Modifier.size(iconSize)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconHLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    animationDuration: Int
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Text(
+        text = title,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = FontWeight.Medium,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun IconHConnector(
+    modifier: Modifier,
+    isPrevious: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    thickness: Dp
+) {
+    val fill by animateFloatAsState(
+        targetValue = if (isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "fill"
+    )
+    Canvas(modifier = modifier.height(thickness)) {
+        val y = size.height / 2
+        drawLine(
+            color = inactiveColor.copy(alpha = 0.35f),
+            start = Offset(0f, y),
+            end = Offset(size.width, y),
+            strokeWidth = size.height,
+            cap = StrokeCap.Round
+        )
+        if (fill > 0f) {
+            drawLine(
+                color = activeColor,
+                start = Offset(0f, y),
+                end = Offset(size.width * fill, y),
+                strokeWidth = size.height,
+                cap = StrokeCap.Round
+            )
+        }
+    }
+}
+// ─── Previews ───────────────────────────────────────────────────────────────
+
+
+private val previewIcons = listOf(
+    Icons.Rounded.Person,
+    Icons.Rounded.Home,
+    Icons.Rounded.ShoppingCart,
+    Icons.Rounded.Star
+)
+
+@Preview(name = "HorizontalIcon – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalIconPreview_Step1() {
+    HorizontalIconStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Profile", "Home", "Cart", "Done"),
+        icons = previewIcons,
+        currentStep = 0,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF78350F),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalIcon – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalIconPreview_Step2() {
+    HorizontalIconStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Profile", "Home", "Cart", "Done"),
+        icons = previewIcons,
+        currentStep = 2,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF78350F),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalIcon – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalIconPreview_Complete() {
+    HorizontalIconStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Profile", "Home", "Cart", "Done"),
+        icons = previewIcons,
+        currentStep = 3,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF78350F),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalNumberedStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalNumberedStepper.kt
@@ -1,0 +1,348 @@
+package com.example.stepmotionlib.horizontal_steppers
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * A horizontal stepper where inactive steps are outlined circles (no fill),
+ * the current step is a filled circle with a translucent outer ring, and
+ * completed steps show a checkmark. Inspired by modern NFT/flow UI designs.
+ *
+ * @param steps List of step labels to display
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for completed and current steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed steps
+ * @param inactiveTitleColor Text color for future steps
+ * @param modifier Modifier to be applied to the stepper
+ * @param circleSize Size of the step indicator circles
+ * @param circleFontSize Font size for numbers inside circles
+ * @param titleFontSize Font size for step labels
+ * @param spacing Vertical spacing between circles and labels
+ * @param connectorThickness Thickness of connector lines
+ * @param outerRingWidth Width of the outer ring drawn around the current step
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun HorizontalNumberedStepper(
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    circleSize: Dp = StepperDefaults.SmallCircleSize,
+    circleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.MediumTitleFontSize,
+    spacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.MediumConnector,
+    outerRingWidth: Dp = 2.dp,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    // Extra space around circleSize to accommodate the outer ring
+    val ringPadding = outerRingWidth + 4.dp
+    val totalSize = circleSize + ringPadding * 2
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        steps.forEachIndexed { index, title ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.wrapContentWidth()
+            ) {
+                NumberedHIndicator(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    circleSize = circleSize,
+                    totalSize = totalSize,
+                    circleFontSize = circleFontSize,
+                    outerRingWidth = outerRingWidth,
+                    animationDuration = animationDuration
+                )
+                Spacer(modifier = Modifier.height(spacing))
+                NumberedHLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    animationDuration = animationDuration
+                )
+            }
+
+            if (index < steps.lastIndex) {
+                NumberedHConnector(
+                    modifier = Modifier
+                        .weight(1f)
+                        .align(Alignment.Top)
+                        .padding(
+                            top = totalSize / 2 - connectorThickness / 2,
+                            start = 4.dp,
+                            end = 4.dp
+                        ),
+                    isPrevious = index < currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    thickness = connectorThickness,
+                    animationDuration = animationDuration
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberedHIndicator(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    circleSize: Dp,
+    totalSize: Dp,
+    circleFontSize: TextUnit,
+    outerRingWidth: Dp,
+    animationDuration: Int
+) {
+    val fillAlpha by animateFloatAsState(
+        targetValue = if (isNext) 0f else 1f,
+        animationSpec = tween(animationDuration),
+        label = "fillAlpha"
+    )
+
+    val strokeColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.45f) else activeColor,
+        animationSpec = tween(animationDuration),
+        label = "strokeColor"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.55f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "contentColor"
+    )
+
+    val outerRingAlpha by animateFloatAsState(
+        targetValue = if (isCurrent) 0.25f else 0f,
+        animationSpec = tween(animationDuration),
+        label = "outerRingAlpha"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.06f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(totalSize)
+            .scale(scale)
+    ) {
+        // Outer translucent ring for current step
+        Box(
+            modifier = Modifier
+                .size(totalSize)
+                .drawBehind {
+                    if (outerRingAlpha > 0f) {
+                        drawCircle(
+                            color = activeColor.copy(alpha = outerRingAlpha),
+                            radius = size.minDimension / 2,
+                            style = Stroke(width = outerRingWidth.toPx() * 2.5f)
+                        )
+                    }
+                }
+        )
+        // Main step circle
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(circleSize)
+                .drawBehind {
+                    drawCircle(color = activeColor.copy(alpha = fillAlpha))
+                    drawCircle(
+                        color = strokeColor,
+                        style = Stroke(width = 2.dp.toPx())
+                    )
+                }
+        ) {
+            AnimatedContent(
+                targetState = isPrevious,
+                transitionSpec = {
+                    (fadeIn(tween(300)) + scaleIn(tween(300)))
+                        .togetherWith(fadeOut(tween(300)) + scaleOut(tween(300)))
+                },
+                label = "stepContent"
+            ) { showCheck ->
+                if (showCheck) {
+                    Image(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(Color.White),
+                        modifier = Modifier.size(circleSize * 0.55f)
+                    )
+                } else {
+                    Text(
+                        text = stepNumber,
+                        color = contentColor,
+                        fontSize = circleFontSize,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberedHLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    animationDuration: Int
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Text(
+        text = title,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun NumberedHConnector(
+    modifier: Modifier,
+    isPrevious: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    thickness: Dp,
+    animationDuration: Int
+) {
+    val fill by animateFloatAsState(
+        targetValue = if (isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "fill"
+    )
+    Canvas(modifier = modifier.height(thickness)) {
+        val y = size.height / 2
+        drawLine(
+            color = inactiveColor.copy(alpha = 0.35f),
+            start = Offset(0f, y),
+            end = Offset(size.width, y),
+            strokeWidth = size.height,
+            cap = StrokeCap.Round
+        )
+        if (fill > 0f) {
+            drawLine(
+                color = activeColor,
+                start = Offset(0f, y),
+                end = Offset(size.width * fill, y),
+                strokeWidth = size.height,
+                cap = StrokeCap.Round
+            )
+        }
+    }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "HorizontalNumbered – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalNumberedPreview_Step1() {
+    HorizontalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Review", "Payment", "Confirm"),
+        currentStep = 0,
+        activeColor = Color(0xFF7C3AED),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF4C1D95),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalNumbered – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalNumberedPreview_Step2() {
+    HorizontalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Review", "Payment", "Confirm"),
+        currentStep = 2,
+        activeColor = Color(0xFF7C3AED),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF4C1D95),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalNumbered – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalNumberedPreview_Complete() {
+    HorizontalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Review", "Payment", "Confirm"),
+        currentStep = 3,
+        activeColor = Color(0xFF7C3AED),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF4C1D95),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalProgressBarStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalProgressBarStepper.kt
@@ -1,0 +1,330 @@
+package com.example.stepmotionlib.horizontal_steppers
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * A horizontal stepper styled as a continuous progress bar with step dots placed on top.
+ * The bar fills progressively as steps are completed, giving a clear sense of overall progress.
+ * Step dots are solid circles that sit on the bar; labels appear below.
+ *
+ * @param steps List of step labels
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for the filled bar and active/completed dots
+ * @param inactiveColor Color for the unfilled bar and future dots
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param dotSize Diameter of each step dot
+ * @param barThickness Height/thickness of the progress bar
+ * @param dotFontSize Font size for numbers inside dots
+ * @param titleFontSize Font size for step labels
+ * @param labelSpacing Vertical spacing between bar row and labels
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun HorizontalProgressBarStepper(
+    modifier: Modifier = Modifier,
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    dotSize: Dp = StepperDefaults.SmallCircleSize,
+    barThickness: Dp = 6.dp,
+    dotFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.SmallTitleFontSize,
+    labelSpacing: Dp = StepperDefaults.LargeSpacing,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            steps.forEachIndexed { index, _ ->
+                ProgressDot(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    dotSize = dotSize,
+                    dotFontSize = dotFontSize,
+                    animationDuration = animationDuration
+                )
+
+                if (index < steps.lastIndex) {
+                    ProgressBarSegment(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(barThickness),
+                        isPrevious = index < currentStep,
+                        isCurrent = index == currentStep,
+                        activeColor = activeColor,
+                        inactiveColor = inactiveColor,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(labelSpacing))
+
+        // Labels row — aligned to match dot positions
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top
+        ) {
+            steps.forEachIndexed { index, title ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.wrapContentWidth()
+                ) {
+                    ProgressBarLabel(
+                        title = title,
+                        isActive = index <= currentStep,
+                        isCurrent = index == currentStep,
+                        activeColor = activeTitleColor,
+                        inactiveColor = inactiveTitleColor,
+                        fontSize = titleFontSize,
+                        animationDuration = animationDuration
+                    )
+                }
+                if (index < steps.lastIndex) Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressDot(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    dotSize: Dp,
+    dotFontSize: TextUnit,
+    animationDuration: Int
+) {
+    val fillColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.3f)
+            else -> activeColor
+        },
+        animationSpec = tween(animationDuration),
+        label = "dotFill"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.6f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "dotContent"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.15f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "dotScale"
+    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(dotSize)
+            .scale(scale)
+            .drawBehind {
+                drawCircle(color = fillColor)
+                // White ring separator so dot pops off the bar
+                drawCircle(
+                    color = Color.White,
+                    radius = size.minDimension / 2,
+                    style = Stroke(width = 2.dp.toPx())
+                )
+                drawCircle(color = fillColor)
+            }
+    ) {
+        AnimatedContent(
+            targetState = isPrevious,
+            transitionSpec = {
+                (fadeIn(tween(280)) + scaleIn(tween(280)))
+                    .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+            },
+            label = "dotContent"
+        ) { showCheck ->
+            if (showCheck) {
+                Image(
+                    imageVector = Icons.Rounded.Check,
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(Color.White),
+                    modifier = Modifier.size(dotSize * 0.5f)
+                )
+            } else {
+                Text(
+                    text = stepNumber,
+                    color = contentColor,
+                    fontSize = dotFontSize,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressBarSegment(
+    modifier: Modifier,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    activeColor: Color,
+    inactiveColor: Color
+) {
+    val fill by animateFloatAsState(
+        targetValue = when {
+            isPrevious -> 1f
+            isCurrent -> 0.5f
+            else -> 0f
+        },
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "segmentFill"
+    )
+
+    Canvas(modifier = modifier) {
+        val y = size.height / 2
+        // Full background
+        drawLine(
+            color = inactiveColor.copy(alpha = 0.25f),
+            start = Offset(0f, y),
+            end = Offset(size.width, y),
+            strokeWidth = size.height,
+            cap = StrokeCap.Butt
+        )
+        // Animated fill
+        if (fill > 0f) {
+            drawLine(
+                color = activeColor,
+                start = Offset(0f, y),
+                end = Offset(size.width * fill, y),
+                strokeWidth = size.height,
+                cap = StrokeCap.Butt
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProgressBarLabel(
+    title: String,
+    isActive: Boolean,
+    isCurrent: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    animationDuration: Int
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Text(
+        text = title,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 2.dp)
+    )
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "HorizontalProgressBar – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalProgressBarPreview_Step1() {
+    HorizontalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Start", "Design", "Build", "Test", "Ship"),
+        currentStep = 0,
+        activeColor = Color(0xFFEF4444),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF7F1D1D),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}
+
+@Preview(name = "HorizontalProgressBar – Step 3", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalProgressBarPreview_Step3() {
+    HorizontalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Start", "Design", "Build", "Test", "Ship"),
+        currentStep = 2,
+        activeColor = Color(0xFFEF4444),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF7F1D1D),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}
+
+@Preview(name = "HorizontalProgressBar – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalProgressBarPreview_Complete() {
+    HorizontalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Start", "Design", "Build", "Test", "Ship"),
+        currentStep = 4,
+        activeColor = Color(0xFFEF4444),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF7F1D1D),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalRoundedStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalRoundedStepper.kt
@@ -1,0 +1,325 @@
+package com.example.stepmotionlib.horizontal_steppers
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * A horizontal stepper using rounded-rectangle badges instead of circles.
+ * Inactive steps show a muted filled badge, current step is full active color,
+ * and completed steps display a checkmark. Corner radius is configurable —
+ * not fully rounded (not a pill/circle), just softly cornered.
+ *
+ * @param steps List of step labels
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for active and completed steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param badgeWidth Width of each step badge
+ * @param badgeHeight Height of each step badge
+ * @param cornerRadius Corner radius of the badge (not fully rounded)
+ * @param badgeFontSize Font size for numbers/check inside badges
+ * @param titleFontSize Font size for step labels below badges
+ * @param spacing Vertical spacing between badges and labels
+ * @param connectorThickness Thickness of connector lines
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun HorizontalRoundedStepper(
+    modifier: Modifier = Modifier,
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    badgeWidth: Dp = 44.dp,
+    badgeHeight: Dp = 32.dp,
+    cornerRadius: Dp = 10.dp,
+    badgeFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.MediumTitleFontSize,
+    spacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.ThinConnector,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        steps.forEachIndexed { index, title ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.wrapContentWidth()
+            ) {
+                RoundedHBadge(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    badgeWidth = badgeWidth,
+                    badgeHeight = badgeHeight,
+                    cornerRadius = cornerRadius,
+                    badgeFontSize = badgeFontSize,
+                    animationDuration = animationDuration
+                )
+                Spacer(modifier = Modifier.height(spacing))
+                RoundedHLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    animationDuration = animationDuration
+                )
+            }
+
+            if (index < steps.lastIndex) {
+                RoundedHConnector(
+                    modifier = Modifier
+                        .weight(1f)
+                        .align(Alignment.Top)
+                        .padding(
+                            top = badgeHeight / 2 - connectorThickness / 2,
+                            start = 4.dp,
+                            end = 4.dp
+                        ),
+                    isPrevious = index < currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    thickness = connectorThickness,
+                    animationDuration = animationDuration
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoundedHBadge(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    badgeWidth: Dp,
+    badgeHeight: Dp,
+    cornerRadius: Dp,
+    badgeFontSize: TextUnit,
+    animationDuration: Int
+) {
+    val badgeColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.2f)
+            else -> activeColor
+        },
+        animationSpec = tween(animationDuration),
+        label = "badgeColor"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.5f)
+            else -> Color.White
+        },
+        animationSpec = tween(animationDuration),
+        label = "contentColor"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.08f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    Card(
+        modifier = Modifier
+            .size(width = badgeWidth, height = badgeHeight)
+            .scale(scale),
+        shape = RoundedCornerShape(cornerRadius),
+        colors = CardDefaults.cardColors(containerColor = badgeColor),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = if (isCurrent) 4.dp else 0.dp
+        )
+    ) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            AnimatedContent(
+                targetState = isPrevious,
+                transitionSpec = {
+                    (fadeIn(tween(280)) + scaleIn(tween(280)))
+                        .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+                },
+                label = "badgeContent"
+            ) { showCheck ->
+                if (showCheck) {
+                    Image(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(Color.White),
+                        modifier = Modifier.size(badgeHeight * 0.55f)
+                    )
+                } else {
+                    Text(
+                        text = stepNumber,
+                        color = contentColor,
+                        fontSize = badgeFontSize,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoundedHLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    animationDuration: Int
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Text(
+        text = title,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = FontWeight.Medium,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun RoundedHConnector(
+    modifier: Modifier,
+    isPrevious: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    thickness: Dp,
+    animationDuration: Int
+) {
+    val fill by animateFloatAsState(
+        targetValue = if (isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "fill"
+    )
+    Canvas(modifier = modifier.height(thickness)) {
+        val y = size.height / 2
+        drawLine(
+            color = inactiveColor.copy(alpha = 0.3f),
+            start = Offset(0f, y),
+            end = Offset(size.width, y),
+            strokeWidth = size.height,
+            cap = StrokeCap.Butt
+        )
+        if (fill > 0f) {
+            drawLine(
+                color = activeColor,
+                start = Offset(0f, y),
+                end = Offset(size.width * fill, y),
+                strokeWidth = size.height,
+                cap = StrokeCap.Butt
+            )
+        }
+    }
+}
+
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "HorizontalRounded – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalRoundedPreview_Step1() {
+    HorizontalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Symptoms", "History", "Rx", "Done"),
+        currentStep = 0,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF064E3B),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}
+
+@Preview(name = "HorizontalRounded – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalRoundedPreview_Step2() {
+    HorizontalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Symptoms", "History", "Rx", "Done"),
+        currentStep = 2,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF064E3B),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}
+
+@Preview(name = "HorizontalRounded – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalRoundedPreview_Complete() {
+    HorizontalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Symptoms", "History", "Rx", "Done"),
+        currentStep = 3,
+        activeColor = Color(0xFF10B981),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF064E3B),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/horizontal_steppers/HorizontalStepper.kt
@@ -1,4 +1,4 @@
-package com.example.stepmotionlib
+package com.example.stepmotionlib.horizontal_steppers
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
@@ -43,6 +43,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * A horizontal stepper component that displays steps with circle indicators and text labels.
@@ -64,14 +66,14 @@ import androidx.compose.ui.unit.dp
  * @param animationDuration Duration of color and scale animations in milliseconds
  */
 @Composable
-fun HorizontalSimpleStepper(
+fun HorizontalStepper(
+    modifier: Modifier = Modifier,
     steps: List<String>,
     currentStep: Int,
     activeColor: Color,
     inactiveColor: Color,
     activeTitleColor: Color,
     inactiveTitleColor: Color,
-    modifier: Modifier = Modifier,
     circleSize: Dp = StepperDefaults.SmallCircleSize,
     circleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
     titleFontSize: TextUnit = StepperDefaults.MediumTitleFontSize,
@@ -79,41 +81,23 @@ fun HorizontalSimpleStepper(
     connectorThickness: Dp = StepperDefaults.ThinConnector,
     borderWidth: Dp = StepperDefaults.BorderWidth,
     animationDuration: Int = StepperDefaults.ColorAnimationDuration,
-    // Legacy parameters for backward compatibility (prefer using new parameter names above)
-    titleList: List<String>? = null,
-    countingList: List<Int>? = null,
-    selectedItemIndex: Int? = null,
-    selectedItemColor: Color? = null,
-    nonSelectedItemColor: Color? = null,
-    selectedTitleColor: Color? = null,
-    nonSelectedTitleColor: Color? = null,
 ) {
-    // Handle backward compatibility
-    val actualSteps = titleList ?: steps
-    val actualCurrentStep = selectedItemIndex ?: currentStep
-    val actualActiveColor = selectedItemColor ?: activeColor
-    val actualInactiveColor = nonSelectedItemColor ?: inactiveColor
-    val actualActiveTitleColor = selectedTitleColor ?: activeTitleColor
-    val actualInactiveTitleColor = nonSelectedTitleColor ?: inactiveTitleColor
-
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Top
     ) {
-        actualSteps.forEachIndexed { index, title ->
-            // Column containing circle and text, centered
+        steps.forEachIndexed { index, title ->
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.wrapContentWidth()
             ) {
-                // Circle indicator
                 StepIndicator(
                     stepNumber = (index + 1).toString(),
-                    isPrevious = index < actualCurrentStep,
-                    isCurrent = index == actualCurrentStep,
-                    isNext = index > actualCurrentStep,
-                    activeColor = actualActiveColor,
-                    inactiveColor = actualInactiveColor,
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
                     circleSize = circleSize,
                     circleFontSize = circleFontSize,
                     borderWidth = borderWidth,
@@ -122,28 +106,26 @@ fun HorizontalSimpleStepper(
 
                 Spacer(modifier = Modifier.height(spacing))
 
-                // Text label
                 StepLabel(
                     title = title,
-                    isActive = index <= actualCurrentStep,
-                    activeColor = actualActiveTitleColor,
-                    inactiveColor = actualInactiveTitleColor,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
                     fontSize = titleFontSize,
                     animationDuration = animationDuration
                 )
             }
 
-            // Connector line (only for non-last items)
-            if (index < actualSteps.lastIndex) {
+            if (index < steps.lastIndex) {
                 ConnectorLine(
                     modifier = Modifier
                         .weight(1f)
                         .align(Alignment.Top)
                         .padding(top = circleSize / 2 - connectorThickness / 2, start = 4.dp, end = 4.dp),
-                    isPrevious = index < actualCurrentStep,
-                    isCurrent = index == actualCurrentStep,
-                    activeColor = actualActiveColor,
-                    inactiveColor = actualInactiveColor,
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
                     thickness = connectorThickness
                 )
             }
@@ -301,4 +283,50 @@ private fun ConnectorLine(
             )
         }
     }
+}
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "HorizontalSimple – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalSimplePreview_Step1() {
+    HorizontalStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Address", "Payment", "Done"),
+        currentStep = 0,
+        activeColor = Color(0xFF3B82F6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF1E40AF),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalSimple – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalSimplePreview_Step2() {
+    HorizontalStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Address", "Payment", "Done"),
+        currentStep = 1,
+        activeColor = Color(0xFF3B82F6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF1E40AF),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "HorizontalSimple – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun HorizontalSimplePreview_Complete() {
+    HorizontalStepper(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        steps = listOf("Details", "Address", "Payment", "Done"),
+        currentStep = 3,
+        activeColor = Color(0xFF3B82F6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF1E40AF),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
 }

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalCardStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalCardStepper.kt
@@ -1,4 +1,4 @@
-package com.example.stepmotionlib
+package com.example.stepmotionlib.vertical_stepper
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
@@ -45,6 +45,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * A vertical card stepper component that displays steps with circle indicators and expandable cards.
@@ -352,4 +354,63 @@ private fun StepCard(
             }
         }
     }
+}
+
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+private val cardSteps = listOf("Create Account", "Personal Info", "Verify", "All Set!")
+private val cardDescs = listOf(
+    "Sign up with your email",
+    "Tell us your name and details",
+    "Verify your email address",
+    "Your account is ready"
+)
+
+@Preview(name = "VerticalCard – Step 1", showBackground = true, widthDp = 360)
+@Composable
+private fun VerticalCardPreview_Step1() {
+    VerticalCardStepper(
+        modifier = Modifier.fillMaxWidth(),
+        steps = cardSteps,
+        descriptions = cardDescs,
+        currentStep = 0,
+        activeColor = Color(0xFF8B5CF6),
+        inactiveColor = Color(0xFF94A3B8),
+        activeCardBackgroundColor = Color(0xFFF5F3FF),
+        cardBackgroundColor = Color(0xFFFFFFFF)
+    )
+}
+
+@Preview(name = "VerticalCard – Step 2", showBackground = true, widthDp = 360)
+@Composable
+private fun VerticalCardPreview_Step2() {
+    VerticalCardStepper(
+        modifier = Modifier.fillMaxWidth(),
+        steps = cardSteps,
+        descriptions = cardDescs,
+        currentStep = 2,
+        activeColor = Color(0xFF8B5CF6),
+        inactiveColor = Color(0xFF94A3B8),
+        activeCardBackgroundColor = Color(0xFFF5F3FF),
+        cardBackgroundColor = Color(0xFFFFFFFF)
+    )
+}
+
+@Preview(name = "VerticalCard – Complete", showBackground = true, widthDp = 360)
+@Composable
+private fun VerticalCardPreview_Complete() {
+    VerticalCardStepper(
+        modifier = Modifier.fillMaxWidth(),
+        steps = cardSteps,
+        descriptions = cardDescs,
+        currentStep = 3,
+        activeColor = Color(0xFF8B5CF6),
+        inactiveColor = Color(0xFF94A3B8),
+        activeCardBackgroundColor = Color(0xFFF5F3FF),
+        cardBackgroundColor = Color(0xFFFFFFFF)
+    )
 }

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalIconStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalIconStepper.kt
@@ -1,0 +1,339 @@
+package com.example.stepmotionlib.vertical_stepper
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.foundation.layout.height
+
+/**
+ * A vertical stepper that shows custom icons inside step indicators.
+ * Inactive steps display the custom icon in an outlined circle (no fill).
+ * The current step shows the icon filled with active color (icon in white).
+ * Completed steps replace the icon with a checkmark.
+ *
+ * @param steps List of step labels
+ * @param icons List of icons matching steps (one icon per step)
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for active and completed steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param circleSize Size of the step indicator circles
+ * @param iconSize Size of the icons inside circles
+ * @param titleFontSize Font size for step labels
+ * @param horizontalSpacing Spacing between the indicator column and labels
+ * @param verticalSpacing Spacing between connector line and circles
+ * @param connectorThickness Thickness of connector lines
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun VerticalIconStepper(
+    steps: List<String>,
+    icons: List<ImageVector>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    circleSize: Dp = StepperDefaults.SmallCircleSize,
+    iconSize: Dp = 18.dp,
+    titleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    horizontalSpacing: Dp = 16.dp,
+    verticalSpacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.ThinConnector,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(horizontal = horizontalSpacing),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            steps.forEachIndexed { index, _ ->
+                IconVIndicator(
+                    icon = icons.getOrNull(index),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    isEndNode = index == steps.lastIndex,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    circleSize = circleSize,
+                    iconSize = iconSize,
+                    verticalSpacing = verticalSpacing,
+                    connectorThickness = connectorThickness,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            steps.forEachIndexed { index, title ->
+                IconVLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    isEndNode = index == steps.lastIndex,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconVIndicator(
+    icon: ImageVector?,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    isEndNode: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    circleSize: Dp,
+    iconSize: Dp,
+    verticalSpacing: Dp,
+    connectorThickness: Dp,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val fillAlpha by animateFloatAsState(
+        targetValue = if (isNext) 0f else 1f,
+        animationSpec = tween(animationDuration),
+        label = "fillAlpha"
+    )
+
+    val strokeColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.5f) else activeColor,
+        animationSpec = tween(animationDuration),
+        label = "strokeColor"
+    )
+
+    val iconTint by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.55f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "iconTint"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.1f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    val connectorFill by animateFloatAsState(
+        targetValue = if (isCurrent || isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "connectorFill"
+    )
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(circleSize)
+                .scale(scale)
+                .drawBehind {
+                    drawCircle(color = activeColor.copy(alpha = fillAlpha))
+                    drawCircle(
+                        color = strokeColor,
+                        style = Stroke(width = 2.dp.toPx())
+                    )
+                }
+        ) {
+            AnimatedContent(
+                targetState = isPrevious,
+                transitionSpec = {
+                    (fadeIn(tween(280)) + scaleIn(tween(280)))
+                        .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+                },
+                label = "iconContent"
+            ) { showCheck ->
+                if (showCheck) {
+                    Image(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(Color.White),
+                        modifier = Modifier.size(iconSize)
+                    )
+                } else if (icon != null) {
+                    Image(
+                        imageVector = icon,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(iconTint),
+                        modifier = Modifier.size(iconSize)
+                    )
+                }
+            }
+        }
+
+        if (!isEndNode) {
+            Spacer(
+                modifier = Modifier
+                    .padding(vertical = verticalSpacing)
+                    .width(connectorThickness)
+                    .weight(1f)
+                    .drawBehind {
+                        val x = size.width / 2
+                        drawLine(
+                            color = inactiveColor.copy(alpha = 0.3f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = size.width,
+                            cap = StrokeCap.Round
+                        )
+                        if (connectorFill > 0f) {
+                            drawLine(
+                                color = activeColor,
+                                start = Offset(x, 0f),
+                                end = Offset(x, size.height * connectorFill),
+                                strokeWidth = size.width,
+                                cap = StrokeCap.Round
+                            )
+                        }
+                    }
+            )
+        }
+    }
+}
+
+@Composable
+private fun IconVLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    isEndNode: Boolean,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = title,
+            color = color,
+            fontSize = fontSize,
+            fontWeight = FontWeight.Medium
+        )
+        if (!isEndNode) Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+private val vIconPreviewIcons = listOf(
+    Icons.Rounded.Person,
+    Icons.Rounded.Home,
+    Icons.Rounded.Star,
+    Icons.Rounded.Favorite
+)
+
+@Preview(name = "VerticalIcon – Step 1", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalIconPreview_Step1() {
+    VerticalIconStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Account", "Address", "Wishlist", "Favourites"),
+        icons = vIconPreviewIcons,
+        currentStep = 0,
+        activeColor = Color(0xFFEC4899),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF831843),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalIcon – Step 2", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalIconPreview_Step2() {
+    VerticalIconStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Account", "Address", "Wishlist", "Favourites"),
+        icons = vIconPreviewIcons,
+        currentStep = 2,
+        activeColor = Color(0xFFEC4899),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF831843),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalIcon – Complete", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalIconPreview_Complete() {
+    VerticalIconStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Account", "Address", "Wishlist", "Favourites"),
+        icons = vIconPreviewIcons,
+        currentStep = 3,
+        activeColor = Color(0xFFEC4899),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF831843),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalNumberedStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalNumberedStepper.kt
@@ -1,0 +1,357 @@
+package com.example.stepmotionlib.vertical_stepper
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.height
+
+/**
+ * A vertical stepper where inactive steps are outlined circles (no fill),
+ * the current step is a filled circle with a translucent outer ring, and
+ * completed steps show a checkmark. Inspired by modern NFT/flow UI designs.
+ *
+ * @param steps List of step labels to display
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for completed and current steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed steps
+ * @param inactiveTitleColor Text color for future steps
+ * @param modifier Modifier to be applied to the stepper
+ * @param circleSize Size of the step indicator circles
+ * @param circleFontSize Font size for numbers inside circles
+ * @param titleFontSize Font size for step labels
+ * @param horizontalSpacing Spacing between the indicator column and labels
+ * @param verticalSpacing Spacing between connector line and circles
+ * @param connectorThickness Thickness of connector lines
+ * @param outerRingWidth Width of the outer ring around the current step
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun VerticalNumberedStepper(
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    circleSize: Dp = StepperDefaults.SmallCircleSize,
+    circleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    horizontalSpacing: Dp = 16.dp,
+    verticalSpacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.ThinConnector,
+    outerRingWidth: Dp = 2.dp,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    val ringPadding = outerRingWidth + 4.dp
+    val totalSize = circleSize + ringPadding * 2
+
+    Row(modifier = modifier.fillMaxWidth()) {
+        // Left column: indicators + connectors
+        Column(
+            modifier = Modifier.padding(horizontal = horizontalSpacing),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            steps.forEachIndexed { index, _ ->
+                NumberedVIndicator(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    isEndNode = index == steps.lastIndex,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    circleSize = circleSize,
+                    totalSize = totalSize,
+                    circleFontSize = circleFontSize,
+                    verticalSpacing = verticalSpacing,
+                    connectorThickness = connectorThickness,
+                    outerRingWidth = outerRingWidth,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+
+        // Right column: labels
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            steps.forEachIndexed { index, title ->
+                NumberedVLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    isEndNode = index == steps.lastIndex,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberedVIndicator(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    isEndNode: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    circleSize: Dp,
+    totalSize: Dp,
+    circleFontSize: TextUnit,
+    verticalSpacing: Dp,
+    connectorThickness: Dp,
+    outerRingWidth: Dp,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val fillAlpha by animateFloatAsState(
+        targetValue = if (isNext) 0f else 1f,
+        animationSpec = tween(animationDuration),
+        label = "fillAlpha"
+    )
+
+    val strokeColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.45f) else activeColor,
+        animationSpec = tween(animationDuration),
+        label = "strokeColor"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.55f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "contentColor"
+    )
+
+    val outerRingAlpha by animateFloatAsState(
+        targetValue = if (isCurrent) 0.25f else 0f,
+        animationSpec = tween(animationDuration),
+        label = "outerRingAlpha"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.06f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    val connectorFill by animateFloatAsState(
+        targetValue = if (isCurrent || isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "connectorFill"
+    )
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(totalSize)
+                .scale(scale)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(totalSize)
+                    .drawBehind {
+                        if (outerRingAlpha > 0f) {
+                            drawCircle(
+                                color = activeColor.copy(alpha = outerRingAlpha),
+                                radius = size.minDimension / 2,
+                                style = Stroke(width = outerRingWidth.toPx() * 2.5f)
+                            )
+                        }
+                    }
+            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(circleSize)
+                    .drawBehind {
+                        drawCircle(color = activeColor.copy(alpha = fillAlpha))
+                        drawCircle(
+                            color = strokeColor,
+                            style = Stroke(width = 2.dp.toPx())
+                        )
+                    }
+            ) {
+                AnimatedContent(
+                    targetState = isPrevious,
+                    transitionSpec = {
+                        (fadeIn(tween(300)) + scaleIn(tween(300)))
+                            .togetherWith(fadeOut(tween(300)) + scaleOut(tween(300)))
+                    },
+                    label = "stepContent"
+                ) { showCheck ->
+                    if (showCheck) {
+                        Image(
+                            imageVector = Icons.Rounded.Check,
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(Color.White),
+                            modifier = Modifier.size(circleSize * 0.55f)
+                        )
+                    } else {
+                        Text(
+                            text = stepNumber,
+                            color = contentColor,
+                            fontSize = circleFontSize,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!isEndNode) {
+            Spacer(
+                modifier = Modifier
+                    .padding(vertical = verticalSpacing)
+                    .width(connectorThickness)
+                    .weight(1f)
+                    .drawBehind {
+                        val x = size.width / 2
+                        drawLine(
+                            color = inactiveColor.copy(alpha = 0.3f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = size.width,
+                            cap = StrokeCap.Round
+                        )
+                        if (connectorFill > 0f) {
+                            drawLine(
+                                color = activeColor,
+                                start = Offset(x, 0f),
+                                end = Offset(x, size.height * connectorFill),
+                                strokeWidth = size.width,
+                                cap = StrokeCap.Round
+                            )
+                        }
+                    }
+            )
+        }
+    }
+}
+
+@Composable
+private fun NumberedVLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    isEndNode: Boolean,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = title,
+            color = color,
+            fontSize = fontSize,
+            fontWeight = FontWeight.SemiBold
+        )
+        if (!isEndNode) Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "VerticalNumbered – Step 1", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalNumberedPreview_Step1() {
+    VerticalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Setup", "Configure", "Preview", "Launch"),
+        currentStep = 0,
+        activeColor = Color(0xFF0EA5E9),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF0C4A6E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalNumbered – Step 2", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalNumberedPreview_Step2() {
+    VerticalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Setup", "Configure", "Preview", "Launch"),
+        currentStep = 2,
+        activeColor = Color(0xFF0EA5E9),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF0C4A6E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalNumbered – Complete", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalNumberedPreview_Complete() {
+    VerticalNumberedStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Setup", "Configure", "Preview", "Launch"),
+        currentStep = 3,
+        activeColor = Color(0xFF0EA5E9),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF0C4A6E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalProgressBarStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalProgressBarStepper.kt
@@ -1,0 +1,327 @@
+package com.example.stepmotionlib.vertical_stepper
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.height
+
+/**
+ * A vertical stepper styled as a continuous progress bar with step dots placed along it.
+ * The bar runs vertically on the left, fills progressively, and labels appear to the right.
+ *
+ * @param steps List of step labels
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for the filled bar and active/completed dots
+ * @param inactiveColor Color for the unfilled bar and future dots
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param dotSize Diameter of each step dot
+ * @param barThickness Width/thickness of the vertical progress bar
+ * @param dotFontSize Font size for numbers inside dots
+ * @param titleFontSize Font size for step labels
+ * @param horizontalSpacing Spacing between the bar column and labels
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun VerticalProgressBarStepper(
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    dotSize: Dp = StepperDefaults.SmallCircleSize,
+    barThickness: Dp = 6.dp,
+    dotFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    horizontalSpacing: Dp = 16.dp,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        // Left column: bar + dots
+        Column(
+            modifier = Modifier.padding(horizontal = horizontalSpacing),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            steps.forEachIndexed { index, _ ->
+                VProgressDot(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    isEndNode = index == steps.lastIndex,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    dotSize = dotSize,
+                    barThickness = barThickness,
+                    dotFontSize = dotFontSize,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+
+        // Right column: labels
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            steps.forEachIndexed { index, title ->
+                VProgressLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    isCurrent = index == currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    isEndNode = index == steps.lastIndex,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VProgressDot(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    isEndNode: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    dotSize: Dp,
+    barThickness: Dp,
+    dotFontSize: TextUnit,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val fillColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.3f)
+            else -> activeColor
+        },
+        animationSpec = tween(animationDuration),
+        label = "dotFill"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isNext) inactiveColor.copy(alpha = 0.6f) else Color.White,
+        animationSpec = tween(animationDuration),
+        label = "dotContent"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.15f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "dotScale"
+    )
+
+    val segmentFill by animateFloatAsState(
+        targetValue = when {
+            isPrevious -> 1f
+            isCurrent -> 0.5f
+            else -> 0f
+        },
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "segmentFill"
+    )
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Dot indicator
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(dotSize)
+                .scale(scale)
+                .drawBehind {
+                    drawCircle(color = fillColor)
+                    drawCircle(
+                        color = Color.White,
+                        radius = size.minDimension / 2,
+                        style = Stroke(width = 2.dp.toPx())
+                    )
+                    drawCircle(color = fillColor)
+                }
+        ) {
+            AnimatedContent(
+                targetState = isPrevious,
+                transitionSpec = {
+                    (fadeIn(tween(280)) + scaleIn(tween(280)))
+                        .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+                },
+                label = "dotContent"
+            ) { showCheck ->
+                if (showCheck) {
+                    Image(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(Color.White),
+                        modifier = Modifier.size(dotSize * 0.5f)
+                    )
+                } else {
+                    Text(
+                        text = stepNumber,
+                        color = contentColor,
+                        fontSize = dotFontSize,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+
+        // Bar segment below (if not the last step)
+        if (!isEndNode) {
+            Spacer(
+                modifier = Modifier
+                    .width(barThickness)
+                    .weight(1f)
+                    .drawBehind {
+                        val x = size.width / 2
+                        drawLine(
+                            color = inactiveColor.copy(alpha = 0.25f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = size.width,
+                            cap = StrokeCap.Butt
+                        )
+                        if (segmentFill > 0f) {
+                            drawLine(
+                                color = activeColor,
+                                start = Offset(x, 0f),
+                                end = Offset(x, size.height * segmentFill),
+                                strokeWidth = size.width,
+                                cap = StrokeCap.Butt
+                            )
+                        }
+                    }
+            )
+        }
+    }
+}
+
+@Composable
+private fun VProgressLabel(
+    title: String,
+    isActive: Boolean,
+    isCurrent: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    isEndNode: Boolean,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = title,
+            color = color,
+            fontSize = fontSize,
+            fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal
+        )
+        if (!isEndNode) Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "VerticalProgressBar – Step 1", showBackground = true, widthDp = 360, heightDp = 320)
+@Composable
+private fun VerticalProgressBarPreview_Step1() {
+    VerticalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().height(300.dp),
+        steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+        currentStep = 0,
+        activeColor = Color(0xFF14B8A6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF134E4A),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}
+
+@Preview(name = "VerticalProgressBar – Step 3", showBackground = true, widthDp = 360, heightDp = 320)
+@Composable
+private fun VerticalProgressBarPreview_Step3() {
+    VerticalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().height(300.dp),
+        steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+        currentStep = 2,
+        activeColor = Color(0xFF14B8A6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF134E4A),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}
+
+@Preview(name = "VerticalProgressBar – Complete", showBackground = true, widthDp = 360, heightDp = 320)
+@Composable
+private fun VerticalProgressBarPreview_Complete() {
+    VerticalProgressBarStepper(
+        modifier = Modifier.fillMaxWidth().height(300.dp),
+        steps = listOf("Order placed", "Processing", "Shipped", "Out for delivery", "Delivered"),
+        currentStep = 4,
+        activeColor = Color(0xFF14B8A6),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF134E4A),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        barThickness = 6.dp
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalRoundedStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalRoundedStepper.kt
@@ -1,0 +1,335 @@
+package com.example.stepmotionlib.vertical_stepper
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.height
+
+/**
+ * A vertical stepper using rounded-rectangle badges instead of circles.
+ * Inactive steps show a muted filled badge, current step is full active color,
+ * and completed steps display a checkmark. Corner radius is configurable —
+ * not fully rounded (not a pill/circle), just softly cornered.
+ *
+ * @param steps List of step labels
+ * @param currentStep Current step index (0-based)
+ * @param activeColor Color for active and completed steps
+ * @param inactiveColor Color for future steps
+ * @param activeTitleColor Text color for active/completed labels
+ * @param inactiveTitleColor Text color for future labels
+ * @param modifier Modifier applied to the stepper
+ * @param badgeWidth Width of each step badge
+ * @param badgeHeight Height of each step badge
+ * @param cornerRadius Corner radius of the badge (not fully rounded)
+ * @param badgeFontSize Font size for numbers/check inside badges
+ * @param titleFontSize Font size for step labels
+ * @param horizontalSpacing Spacing between the badge column and labels
+ * @param verticalSpacing Spacing between connector and badge
+ * @param connectorThickness Thickness of connector lines
+ * @param animationDuration Duration of animations in milliseconds
+ */
+@Composable
+fun VerticalRoundedStepper(
+    steps: List<String>,
+    currentStep: Int,
+    activeColor: Color,
+    inactiveColor: Color,
+    activeTitleColor: Color,
+    inactiveTitleColor: Color,
+    modifier: Modifier = Modifier,
+    badgeWidth: Dp = 44.dp,
+    badgeHeight: Dp = 32.dp,
+    cornerRadius: Dp = 10.dp,
+    badgeFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    titleFontSize: TextUnit = StepperDefaults.CircleNumberFontSize,
+    horizontalSpacing: Dp = 16.dp,
+    verticalSpacing: Dp = StepperDefaults.SmallSpacing,
+    connectorThickness: Dp = StepperDefaults.ThinConnector,
+    animationDuration: Int = StepperDefaults.ColorAnimationDuration,
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(horizontal = horizontalSpacing),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            steps.forEachIndexed { index, _ ->
+                RoundedVBadge(
+                    stepNumber = (index + 1).toString(),
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    isEndNode = index == steps.lastIndex,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
+                    badgeWidth = badgeWidth,
+                    badgeHeight = badgeHeight,
+                    cornerRadius = cornerRadius,
+                    badgeFontSize = badgeFontSize,
+                    verticalSpacing = verticalSpacing,
+                    connectorThickness = connectorThickness,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            steps.forEachIndexed { index, title ->
+                RoundedVLabel(
+                    title = title,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
+                    fontSize = titleFontSize,
+                    isEndNode = index == steps.lastIndex,
+                    animationDuration = animationDuration,
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoundedVBadge(
+    stepNumber: String,
+    isPrevious: Boolean,
+    isCurrent: Boolean,
+    isNext: Boolean,
+    isEndNode: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    badgeWidth: Dp,
+    badgeHeight: Dp,
+    cornerRadius: Dp,
+    badgeFontSize: TextUnit,
+    verticalSpacing: Dp,
+    connectorThickness: Dp,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val badgeColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.2f)
+            else -> activeColor
+        },
+        animationSpec = tween(animationDuration),
+        label = "badgeColor"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = when {
+            isNext -> inactiveColor.copy(alpha = 0.5f)
+            else -> Color.White
+        },
+        animationSpec = tween(animationDuration),
+        label = "contentColor"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (isCurrent) 1.08f else 1f,
+        animationSpec = StepperDefaults.bouncySpring(),
+        label = "scale"
+    )
+
+    val connectorFill by animateFloatAsState(
+        targetValue = if (isCurrent || isPrevious) 1f else 0f,
+        animationSpec = StepperDefaults.smoothSpring(),
+        label = "connectorFill"
+    )
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Card(
+            modifier = Modifier
+                .size(width = badgeWidth, height = badgeHeight)
+                .scale(scale),
+            shape = RoundedCornerShape(cornerRadius),
+            colors = CardDefaults.cardColors(containerColor = badgeColor),
+            elevation = CardDefaults.cardElevation(
+                defaultElevation = if (isCurrent) 4.dp else 0.dp
+            )
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                AnimatedContent(
+                    targetState = isPrevious,
+                    transitionSpec = {
+                        (fadeIn(tween(280)) + scaleIn(tween(280)))
+                            .togetherWith(fadeOut(tween(280)) + scaleOut(tween(280)))
+                    },
+                    label = "badgeContent"
+                ) { showCheck ->
+                    if (showCheck) {
+                        Image(
+                            imageVector = Icons.Rounded.Check,
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(Color.White),
+                            modifier = Modifier.size(badgeHeight * 0.55f)
+                        )
+                    } else {
+                        Text(
+                            text = stepNumber,
+                            color = contentColor,
+                            fontSize = badgeFontSize,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!isEndNode) {
+            Spacer(
+                modifier = Modifier
+                    .padding(vertical = verticalSpacing)
+                    .width(connectorThickness)
+                    .weight(1f)
+                    .drawBehind {
+                        val x = size.width / 2
+                        drawLine(
+                            color = inactiveColor.copy(alpha = 0.3f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = size.width,
+                            cap = StrokeCap.Butt
+                        )
+                        if (connectorFill > 0f) {
+                            drawLine(
+                                color = activeColor,
+                                start = Offset(x, 0f),
+                                end = Offset(x, size.height * connectorFill),
+                                strokeWidth = size.width,
+                                cap = StrokeCap.Butt
+                            )
+                        }
+                    }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RoundedVLabel(
+    title: String,
+    isActive: Boolean,
+    activeColor: Color,
+    inactiveColor: Color,
+    fontSize: TextUnit,
+    isEndNode: Boolean,
+    animationDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    val color by animateColorAsState(
+        targetValue = if (isActive) activeColor else inactiveColor,
+        animationSpec = tween(animationDuration),
+        label = "labelColor"
+    )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = title,
+            color = color,
+            fontSize = fontSize,
+            fontWeight = FontWeight.Medium
+        )
+        if (!isEndNode) Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "VerticalRounded – Step 1", showBackground = true, widthDp = 360, heightDp = 280)
+@Composable
+private fun VerticalRoundedPreview_Step1() {
+    VerticalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().height(260.dp),
+        steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
+        currentStep = 0,
+        activeColor = Color(0xFF6366F1),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF312E81),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}
+
+@Preview(name = "VerticalRounded – Step 2", showBackground = true, widthDp = 360, heightDp = 280)
+@Composable
+private fun VerticalRoundedPreview_Step2() {
+    VerticalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().height(260.dp),
+        steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
+        currentStep = 2,
+        activeColor = Color(0xFF6366F1),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF312E81),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}
+
+@Preview(name = "VerticalRounded – Complete", showBackground = true, widthDp = 360, heightDp = 280)
+@Composable
+private fun VerticalRoundedPreview_Complete() {
+    VerticalRoundedStepper(
+        modifier = Modifier.fillMaxWidth().height(260.dp),
+        steps = listOf("Intake", "Diagnosis", "Prescription", "Follow-up"),
+        currentStep = 3,
+        activeColor = Color(0xFF6366F1),
+        inactiveColor = Color(0xFFCBD5E1),
+        activeTitleColor = Color(0xFF312E81),
+        inactiveTitleColor = Color(0xFF94A3B8),
+        cornerRadius = 10.dp
+    )
+}

--- a/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalStepper.kt
+++ b/stepmotionlib/src/main/java/com/example/stepmotionlib/vertical_stepper/VerticalStepper.kt
@@ -1,4 +1,5 @@
-package com.example.stepmotionlib
+
+package com.example.stepmotionlib.vertical_stepper
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
@@ -42,6 +43,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import com.example.stepmotionlib.StepperDefaults
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.height
 
 /**
  * A vertical stepper component that displays steps with circle indicators and text labels.
@@ -80,67 +84,49 @@ fun VerticalSimpleStepper(
     connectorThickness: Dp = StepperDefaults.ThinConnector,
     borderWidth: Dp = StepperDefaults.BorderWidth,
     animationDuration: Int = StepperDefaults.ColorAnimationDuration,
-    // Legacy parameters for backward compatibility (prefer using new parameter names above)
-    titleList: List<String>? = null,
-    countingList: List<Int>? = null,
-    selectedItemIndex: Int? = null,
-    selectedItemColor: Color? = null,
-    nonSelectedItemColor: Color? = null,
-    selectedTitleColor: Color? = null,
-    nonSelectedTitleColor: Color? = null,
 ) {
-    // Handle backward compatibility
-    val actualSteps = titleList ?: steps
-    val actualCurrentStep = selectedItemIndex ?: currentStep
-    val actualActiveColor = selectedItemColor ?: activeColor
-    val actualInactiveColor = nonSelectedItemColor ?: inactiveColor
-    val actualActiveTitleColor = selectedTitleColor ?: activeTitleColor
-    val actualInactiveTitleColor = nonSelectedTitleColor ?: inactiveTitleColor
-
     Row(
         modifier = modifier.fillMaxWidth()
     ) {
-        // Left column: Circles and connectors
         Column(
             modifier = Modifier.padding(horizontal = horizontalSpacing),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            actualSteps.forEachIndexed { index, _ ->
+            steps.forEachIndexed { index, _ ->
                 VerticalStepIndicator(
                     stepNumber = (index + 1).toString(),
-                    isPrevious = index < actualCurrentStep,
-                    isCurrent = index == actualCurrentStep,
-                    isNext = index > actualCurrentStep,
-                    isEndNode = index == actualSteps.lastIndex,
-                    activeColor = actualActiveColor,
-                    inactiveColor = actualInactiveColor,
+                    isPrevious = index < currentStep,
+                    isCurrent = index == currentStep,
+                    isNext = index > currentStep,
+                    isEndNode = index == steps.lastIndex,
+                    activeColor = activeColor,
+                    inactiveColor = inactiveColor,
                     circleSize = circleSize,
                     circleFontSize = circleFontSize,
                     verticalSpacing = verticalSpacing,
                     connectorThickness = connectorThickness,
                     borderWidth = borderWidth,
                     animationDuration = animationDuration,
-                    modifier = if (index == actualSteps.lastIndex) Modifier else Modifier.weight(1f)
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
                 )
             }
         }
 
-        // Right column: Text labels
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
         ) {
-            actualSteps.forEachIndexed { index, title ->
+            steps.forEachIndexed { index, title ->
                 VerticalStepLabel(
                     title = title,
-                    isActive = index <= actualCurrentStep,
-                    activeColor = actualActiveTitleColor,
-                    inactiveColor = actualInactiveTitleColor,
+                    isActive = index <= currentStep,
+                    activeColor = activeTitleColor,
+                    inactiveColor = inactiveTitleColor,
                     fontSize = titleFontSize,
-                    isEndNode = index == actualSteps.lastIndex,
+                    isEndNode = index == steps.lastIndex,
                     animationDuration = animationDuration,
-                    modifier = if (index == actualSteps.lastIndex) Modifier else Modifier.weight(1f)
+                    modifier = if (index == steps.lastIndex) Modifier else Modifier.weight(1f)
                 )
             }
         }
@@ -320,4 +306,51 @@ private fun VerticalStepLabel(
             Spacer(modifier = Modifier.weight(1f))
         }
     }
+}
+
+
+//********************************//
+//            PREVIEW            //
+//******************************//
+
+@Preview(name = "VerticalSimple – Step 1", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalSimplePreview_Step1() {
+    VerticalSimpleStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Select", "Confirm", "Pay", "Complete"),
+        currentStep = 0,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFE2E8F0),
+        activeTitleColor = Color(0xFF92400E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalSimple – Step 2", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalSimplePreview_Step2() {
+    VerticalSimpleStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Select", "Confirm", "Pay", "Complete"),
+        currentStep = 2,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFE2E8F0),
+        activeTitleColor = Color(0xFF92400E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
+}
+
+@Preview(name = "VerticalSimple – Complete", showBackground = true, widthDp = 360, heightDp = 260)
+@Composable
+private fun VerticalSimplePreview_Complete() {
+    VerticalSimpleStepper(
+        modifier = Modifier.fillMaxWidth().height(240.dp),
+        steps = listOf("Select", "Confirm", "Pay", "Complete"),
+        currentStep = 3,
+        activeColor = Color(0xFFF59E0B),
+        inactiveColor = Color(0xFFE2E8F0),
+        activeTitleColor = Color(0xFF92400E),
+        inactiveTitleColor = Color(0xFF94A3B8)
+    )
 }


### PR DESCRIPTION
This PR continas the following work done:
- 4 new horizontal steppers: HorizontalNumberedStepper (outlined inactive + outer glow ring on current), HorizontalIconStepper (per-step custom ImageVector icons),
  HorizontalRoundedStepper (rounded-rectangle badges, configurable corner radius), HorizontalProgressBarStepper (continuous bar with dots on top)
  - 4 new vertical steppers: matching vertical variants for each of the above
  - API cleanup: removed all backward-compat aliases from HorizontalStepper and VerticalSimpleStepper — clean params only
  - Previews: added @Preview composables to all 12 stepper files for real-time editing in Android Studio
  - Demo screen: reorganized MainActivity so each type group shows horizontal above vertical, separated by labeled dividers                                                          
  - README: fully rewritten to document all 12 steppers with usage examples and parameter tables